### PR TITLE
wayv: fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -33,6 +33,8 @@
 #include "gesture.h"
 #include "process.h"
 
+int child;
+
 /*
  * Purpose:
  *	Carry out a list of actions in a gesture struct

--- a/src/process.h
+++ b/src/process.h
@@ -27,7 +27,7 @@
 #include "display.h"
 #include "gesture.h"
 
-int child;
+extern int child;
 
 void performAction(WSETUP *, WGESTURE *, GDISPLAY *, GPOINT *);
 void destroyZombies(int);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: process.o:(.bss+0x0): multiple definition of `child'; backend.o:(.bss+0x0): first defined here

The change moves 'child' global definition to a .c file.